### PR TITLE
Fpylll changes - dumping gso to double*

### DIFF
--- a/src/gso.h
+++ b/src/gso.h
@@ -476,10 +476,10 @@ inline void MatGSO<ZT, FT>::getR(FT& f, int i, int j) {
 template<class ZT, class FT>
 inline void MatGSO<ZT, FT>::DumpMu_d(double* Mu, int beg, int blocksize){
   FT e;
-  for (int i = beg; i < beg+blocksize; ++i){
-    for (int j = beg; j < beg+blocksize; ++j)
+  for (int i = 0; i < blocksize; ++i){
+    for (int j = 0; j < blocksize; ++j)
     {
-      getMu(e,i,j);
+      getMu(e,i+beg,j+beg);
       Mu[i*blocksize+j] = e.get_d();
     }
   }
@@ -488,8 +488,8 @@ inline void MatGSO<ZT, FT>::DumpMu_d(double* Mu, int beg, int blocksize){
 template<class ZT, class FT>
 inline void MatGSO<ZT, FT>::DumpR_d(double* R, int beg, int blocksize){
   FT e;
-  for (int i = beg; i < beg+blocksize; ++i){
-      getR(e,i,i);
+  for (int i = 0; i < blocksize; ++i){
+      getR(e,i+beg,i+beg);
       R[i] = e.get_d();
   }
 }

--- a/src/gso.h
+++ b/src/gso.h
@@ -167,8 +167,8 @@ public:
    * 
    */
 
-inline void GetSubMuR(double* Mu_t, double* R_t,  int beg, int blocksize);
-
+inline void DumpMu_d(double* Mu, int beg, int blocksize);
+inline void DumpR_d(double* R, int beg, int blocksize);
 
 
 
@@ -474,20 +474,24 @@ inline void MatGSO<ZT, FT>::getR(FT& f, int i, int j) {
 
 
 template<class ZT, class FT>
-inline void MatGSO<ZT, FT>::GetSubMuR(double* Mu_t, double* R_t,  int beg, int blocksize){
+inline void MatGSO<ZT, FT>::DumpMu_d(double* Mu, int beg, int blocksize){
   FT e;
   for (int i = beg; i < beg+blocksize; ++i){
     for (int j = beg; j < beg+blocksize; ++j)
     {
       getMu(e,i,j);
-      Mu_t[i*blocksize+j] = e.get_d();
+      Mu[i*blocksize+j] = e.get_d();
     }
-    getR(e,i,i);
-    R_t[i] = e.get_d();
   }
+}
 
-
-
+template<class ZT, class FT>
+inline void MatGSO<ZT, FT>::DumpR_d(double* R, int beg, int blocksize){
+  FT e;
+  for (int i = beg; i < beg+blocksize; ++i){
+      getR(e,i,i);
+      R[i] = e.get_d();
+  }
 }
 
 

--- a/src/gso.h
+++ b/src/gso.h
@@ -161,6 +161,20 @@ public:
    */
   inline void getR(FT& f, int i, int j);
 
+
+  /** 
+   * Copies submatrix Mu and subvector R to targets
+   * 
+   */
+
+inline void GetSubMuR(double* Mu_t, double* R_t,  int beg, int blocksize);
+
+
+
+
+
+
+
   /** 
    * Returns expo such that mu(i, j) &lt; 2^expo for all j &lt; nColumns.
    * It is assumed that mu(i, j) is valid for all j &lt; nColumns.
@@ -457,6 +471,27 @@ inline void MatGSO<ZT, FT>::getR(FT& f, int i, int j) {
   if (enableRowExpo)
     f.mul_2si(f, rowExpo[i] + rowExpo[j]);
 }
+
+
+template<class ZT, class FT>
+inline void MatGSO<ZT, FT>::GetSubMuR(double* Mu_t, double* R_t,  int beg, int blocksize){
+  FT e;
+  for (int i = beg; i < beg+blocksize; ++i){
+    for (int j = beg; j < beg+blocksize; ++j)
+    {
+      getMu(e,i,j);
+      Mu_t[i*blocksize+j] = e.get_d();
+    }
+    getR(e,i,i);
+    R_t[i] = e.get_d();
+  }
+
+
+
+}
+
+
+
 
 template<class ZT, class FT>
 inline bool MatGSO<ZT, FT>::updateGSORow(int i) {


### PR DESCRIPTION
The patch add two functions to dump gso informations (r and mu) to a given pointer. This should limit the overhead to access those from fpylll. This is joint with a patch for fpylll.
